### PR TITLE
Added reference to docpad = @docpad. 

### DIFF
--- a/src/tagcloud.plugin.coffee
+++ b/src/tagcloud.plugin.coffee
@@ -25,6 +25,7 @@ module.exports = (BasePlugin) ->
 
 		renderBefore: ({collection, templateData}, next) ->
 			config = @getConfig()
+			docpad = @docpad
 
 			@tagCloud = {}	# reset every time renderBefore is triggered
 			@maxCount = 0


### PR DESCRIPTION
Seems to be needed with latest update to docpad.

Tagcloud was working for me until I updated docpad to version 6.65.0 at which point trying to run docpad resulted in an error that docpad was undefined in the tagcloud plugin.

Adding the reference seems to fix the issue.
