### PR TITLE
Make taggedfiles configurable so that the source files can be filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Note that in this example we've added the count and weight here as HTML5 data fi
 - *collectionName* : The collection containing your tag index pages.  This should probably be the same as specified for the tags plugin.
 - *getTagWeight* : Override the function used to generate the tag weights (see below).
 - *logLevel*: Override the log level for log messages from this plugin.  Defaults to 'info'.
+- *getTaggedFiles*: The function to get all source files. Override the default `docpad.getFiles({tags: $has: tag})` to use only a filtered collection like `docpad.getFiles({tags: {$has: tag}, isPublished:true})`.
 
 ### Customising the weight function
 

--- a/src/tagcloud.plugin.coffee
+++ b/src/tagcloud.plugin.coffee
@@ -6,6 +6,8 @@ module.exports = (BasePlugin) ->
 		config:
 			collectionName: 'tags'
 			logLevel: 'info'
+			getTaggedFiles: (docpad, tag) ->
+				return docpad.getFiles({tags: $has: tag})
 
 			getTagWeight: (count, maxCount) ->
 				# apply logarithmic weight algorithm
@@ -26,6 +28,7 @@ module.exports = (BasePlugin) ->
 		renderBefore: ({collection, templateData}, next) ->
 			config = @getConfig()
 			docpad = @docpad
+			plugin = @
 
 			@tagCloud = {}	# reset every time renderBefore is triggered
 			@maxCount = 0
@@ -33,7 +36,7 @@ module.exports = (BasePlugin) ->
 			tagDocs = docpad.getCollection(config.collectionName)
 			tagDocs?.forEach (doc) =>
 				tag = doc?.get('tag')
-				taggedfiles = docpad.getFiles({tags: $has: tag})
+				taggedfiles = config.getTaggedFiles.call(plugin, docpad, tag)
 				count = taggedfiles?.length or 0
 
 				@tagCloud[tag] ?=


### PR DESCRIPTION
I wanted to have not all files included in my tagcloud. Therefore I made the taggedfiles variable point to a configurable function. The changes are:
- added config.getTaggedFiles config parameter
- defaults to previous getFiles function call
- declared plugin variable for reference in getTaggedFiles function call
- replaced docpad.getFiles with config.getTaggedFiles.call
- added list entry for getTaggedFiles in README.md
